### PR TITLE
fix: 可能解决了兑换时间不对的问题

### DIFF
--- a/myseg/data_class.py
+++ b/myseg/data_class.py
@@ -271,9 +271,11 @@ class GoodsInfo(BaseModel):
         """
         获取商品下次兑换时间
         """
-        if self.next_time == 0 or (self.next_time > get_time() and self.total > 0):
+        if self.next_time == 0 or (get_time() > self.next_time and self.total > 0):
             return -1
-        elif self.status == 'online':
+        elif self.next_time == 0:
+            return self.sale_start_time
+        elif self.status == 'online' or self.status == 'not_in_sell':
             return self.next_time
         else:
             return self.sale_start_time

--- a/myseg/mi_tool.py
+++ b/myseg/mi_tool.py
@@ -436,8 +436,8 @@ async def get_goods_list(game_type: str, cookie='') -> Union[bool, Optional[List
             "point_sn": "myb",
             "page_size": 20,
             "page": 1,
-            # '全部商品':'', '崩坏3':'bh3', '原神':'hk4e', '崩坏：星穹铁道':'hkrpg'
-            # '崩坏学园2':'bh2', '未定事件簿':'nxx', '米游社':'bbs'
+            # '全部商品':'', '崩坏3':'bh3', '原神':'hk4e', '绝区零': 'nap',
+            # '崩坏：星穹铁道':'hkrpg', '崩坏学园2':'bh2', '未定事件簿':'nxx', '米游社':'bbs'
             "game": game_type,
         }
         goods_list_headers = {


### PR DESCRIPTION
# 只是可能解决！

### 发现的问题

原神商品(其他商品可能也会)会提前摆放且兑换时间会提前一周显示，并且status会显示为`not_in_sell`，这与判断内写的完全冲突！

我不是很了解这方面，尽自己所能修改，如果有问题可以**close Pull Request**

但我怀疑api返回时间和app内时间不对等可能是**米哈游防脚本的第一步行为**

待下期来的时候再观望吧，暂时先这样了

#### Tip

@GOOD-AN 大佬写的是满足`next_time > getTime() & total > 0 时间戳返回-1`(~这怎么样都会返回-1吧喂！(bushi)~